### PR TITLE
feat(ui): add recursive expand/collapse toggle to json tree viewer

### DIFF
--- a/docs/docs/features/state-visualization.md
+++ b/docs/docs/features/state-visualization.md
@@ -11,7 +11,8 @@ Explore your application state with a tree-based JSON viewer.
 
 The state viewer provides an interactive tree representation of your entire NgRx store state. You can:
 
-- Expand and collapse nested objects
+- Expand and collapse nested objects individually
+- Expand or collapse all nodes at once with the toggle button
 - Search through the state tree
 - Copy values to clipboard
 - View raw JSON

--- a/projects/ngrx-devtool-ui/src/components/json-tree/json-tree.component.html
+++ b/projects/ngrx-devtool-ui/src/components/json-tree/json-tree.component.html
@@ -1,1 +1,7 @@
-<json-viewer [data]="jsonData"></json-viewer>
+<button mat-icon-button
+        class="tree-toggle-btn"
+        [matTooltip]="expanded ? 'Collapse All' : 'Expand All'"
+        (click)="toggle()">
+  <mat-icon>{{ expanded ? 'unfold_less' : 'unfold_more' }}</mat-icon>
+</button>
+<json-viewer #jsonViewer [data]="jsonData"></json-viewer>

--- a/projects/ngrx-devtool-ui/src/components/json-tree/json-tree.component.scss
+++ b/projects/ngrx-devtool-ui/src/components/json-tree/json-tree.component.scss
@@ -1,5 +1,25 @@
 @use '../../styles/theme' as *;
 
+:host {
+    display: block;
+    position: relative;
+    overflow: hidden;
+}
+
+.tree-toggle-btn {
+    position: absolute;
+    top: 0;
+    right: 0;
+    z-index: 1;
+    color: #{$color-on-surface-variant};
+    opacity: 0.6;
+
+    &:hover {
+        opacity: 1;
+        color: #{$color-primary};
+    }
+}
+
 json-viewer {
     --background-color: #{$color-background};
     --property-color: #{$color-primary};

--- a/projects/ngrx-devtool-ui/src/components/json-tree/json-tree.component.ts
+++ b/projects/ngrx-devtool-ui/src/components/json-tree/json-tree.component.ts
@@ -1,16 +1,38 @@
-import { Component, CUSTOM_ELEMENTS_SCHEMA, Input } from '@angular/core';
+import { Component, CUSTOM_ELEMENTS_SCHEMA, ElementRef, Input, ViewChild } from '@angular/core';
+import { MatButtonModule } from '@angular/material/button';
+import { MatIconModule } from '@angular/material/icon';
+import { MatTooltipModule } from '@angular/material/tooltip';
+
 export interface JsonTreeNode {
   key: string;
   value?: string | number | boolean | null;
   children?: JsonTreeNode[];
 }
+
 @Component({
   selector: 'app-json-tree',
-  imports: [],
+  imports: [MatButtonModule, MatIconModule, MatTooltipModule],
   templateUrl: './json-tree.component.html',
   styleUrl: './json-tree.component.scss',
   schemas: [CUSTOM_ELEMENTS_SCHEMA]
 })
-export class JsonTreeComponent{
+export class JsonTreeComponent {
   @Input() jsonData: unknown;
+
+  @ViewChild('jsonViewer', { static: false })
+  jsonViewerRef!: ElementRef;
+
+  expanded = false;
+
+  toggle(): void {
+    const viewer = this.jsonViewerRef?.nativeElement;
+    if (!viewer) return;
+
+    this.expanded = !this.expanded;
+    if (this.expanded && typeof viewer.expandAll === 'function') {
+      viewer.expandAll();
+    } else if (!this.expanded && typeof viewer.collapseAll === 'function') {
+      viewer.collapseAll();
+    }
+  }
 }


### PR DESCRIPTION
[AmadeusITGroup/ngrx-devtool/issues/45
](https://github.com/AmadeusITGroup/ngrx-devtool/issues/45)

## Summary

Add a single toggle button to the JSON tree viewer that recursively expands or collapses all nodes.

## Changes

- **json-tree.component.ts**  Added `@ViewChild` ref, `expanded` state, `toggle()` method, Material module imports
- **json-tree.component.html** Toggle button with dynamic icon/tooltip, `#jsonViewer` template ref
- **json-tree.component.scss**  `:host` positioning with `overflow: hidden`, toggle button absolute positioning and hover styles
- **state-visualization.md**  Updated docs to mention the feature

## How it works

The toggle button delegates to the `@alenaksu/json-viewer` web component's native `expandAll()` and `collapseAll()` methods. It floats in the top-right corner of the viewer, semi-transparent until hovered. `overflow: hidden` on `:host` prevents any scrollbar regression.

## Testing

- All 202 unit tests pass (`npm test`)
- Lint passes (`npm run lint`)


![Recursive  expand collapse](https://github.com/user-attachments/assets/9a683bf8-3220-430e-b776-4166084c1b8c)
